### PR TITLE
make renderWithBaseDir in PlantUmlToolWindow public

### DIFF
--- a/src/org/plantuml/idea/toolwindow/PlantUmlToolWindow.java
+++ b/src/org/plantuml/idea/toolwindow/PlantUmlToolWindow.java
@@ -114,7 +114,7 @@ public class PlantUmlToolWindow extends JPanel {
         });
     }
 
-    private void renderWithBaseDir(String source, File baseDir) {
+    public void renderWithBaseDir(String source, File baseDir) {
         if (source.isEmpty())
             return;
         PlantUmlResult result = PlantUml.render(source, baseDir);


### PR DESCRIPTION
we want to use your plugin in mbeddr (https://github.com/mbeddr/mbeddr.core/) to visualize the statemachines and dependencies. But we are using your tool a bit different from the java use case. In order to avoid reflective calls we needed to make renderWithBaseDir public
