### PR TITLE
Extract embedded PlantUML sources from PNG

### DIFF
--- a/adapter/src/org/plantuml/idea/adapter/FacadeImpl.java
+++ b/adapter/src/org/plantuml/idea/adapter/FacadeImpl.java
@@ -1,7 +1,10 @@
 package org.plantuml.idea.adapter;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.io.IOUtil;
+import net.sourceforge.plantuml.png.MetadataTag;
 import org.jetbrains.annotations.Nullable;
 import org.plantuml.idea.adapter.rendering.PlantUmlExporter;
 import org.plantuml.idea.adapter.rendering.PlantUmlRendererUtil;
@@ -17,6 +20,7 @@ import org.plantuml.idea.toolwindow.Zoom;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -38,6 +42,24 @@ public class FacadeImpl implements PlantUmlFacade {
     @Override
     public void save(String path, byte[] imageBytes) {
          PlantUmlExporter.save(path, imageBytes);
+    }
+
+    @Override
+    public String extractEmbeddedSourceFromImage(VirtualFile file) {
+        try {
+            // based on https://github.com/plantuml/plantuml-server/blob/f4f6ca5773869c7f77b23f6004bea45e3954600f/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlServlet.java#L79
+            // https://plantuml.com/de/server#metadata
+            File img = VfsUtil.virtualToIoFile(file);
+            MetadataTag metadataTag = new MetadataTag(img, "plantuml");
+            String data = metadataTag.getData();
+            if (data != null) {
+                return data;
+            }
+        } catch (IOException e) {
+            //TODO handle exception
+        }
+
+        return null;
     }
 
     @Override

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -206,6 +206,11 @@
             <action id="NewPlantUMLFile" class="org.plantuml.idea.plantuml.CreatePlantUMLFileAction"/>
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
         </group>
+        <action id="extractEmbeddedPlantumlSourcesFromPNG"
+                class="org.plantuml.idea.action.context.ExtractEmbeddedSourcesFromPNGAction"
+                text="Extract PlantUML Source" description="Extracts the embedded source code from PlantUML images">
+            <add-to-group group-id="Images.EditorPopupMenu" anchor="first"/>
+        </action>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/src/org/plantuml/idea/action/context/ExtractEmbeddedSourcesFromPNGAction.java
+++ b/src/org/plantuml/idea/action/context/ExtractEmbeddedSourcesFromPNGAction.java
@@ -1,0 +1,37 @@
+package org.plantuml.idea.action.context;
+
+import com.intellij.ide.scratch.ScratchRootType;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.plantuml.idea.external.PlantUmlFacade;
+import org.plantuml.idea.plantuml.SourceExtractor;
+
+public class ExtractEmbeddedSourcesFromPNGAction extends AnAction {
+
+    @Override
+    public void actionPerformed(AnActionEvent e) {
+        VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
+        if (file == null) {
+            return;
+        }
+        Project project = e.getProject();
+        if (project == null) {
+            return;
+        }
+
+        //Extract source from PNG-metadata
+        String extracted = PlantUmlFacade.get().extractEmbeddedSourceFromImage(file);
+
+        if (extracted != null) {
+            // Remove other code after @enduml
+            extracted = SourceExtractor.extractSource(extracted, 0);
+            // Open extracted source in new scratch file
+            VirtualFile scratchFile = ScratchRootType.getInstance().createScratchFile(project, file.getNameWithoutExtension() + ".puml", null, extracted);
+            if (scratchFile != null) {
+                FileEditorManager.getInstance(project).openFile(scratchFile, true);
+            }
+        }
+    }
+}

--- a/src/org/plantuml/idea/external/PlantUmlFacade.java
+++ b/src/org/plantuml/idea/external/PlantUmlFacade.java
@@ -32,4 +32,6 @@ public interface PlantUmlFacade {
     String encode(String source) throws IOException;
 
     void save(String path, byte[] imageBytes);
+
+    String extractEmbeddedSourceFromImage(VirtualFile file);
 }


### PR DESCRIPTION
It adds an action to the context menu of a PNG. This action extracts the embedded PlantUML source code from  the metadata of the image (if it has been generated by PlantUML) and opens the source code in a new scratch file. This is useful if you have existing complex PlantUML images you like to edit, but you do not have the source code anymore.

Based on the official documentation https://plantuml.com/de/server#metadata
and existing code in the PlantUML server https://github.com/plantuml/plantuml-server/blob/f4f6ca5773869c7f77b23f6004bea45e3954600f/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlServlet.java#L79

Please review.